### PR TITLE
When venv.path is a pathlib.Path object convert it to a string

### DIFF
--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -19,7 +19,7 @@ def _init_pipenv_environ():
 @hookimpl
 def tox_testenv_create(venv, action):
     _init_pipenv_environ()
-    pipfile_path = os.path.join(venv.path, 'Pipfile')
+    pipfile_path = os.path.join(str(venv.path), 'Pipfile')
 
     config_interpreter = venv.getsupportedinterpreter()
     args = [sys.executable, '-m', 'pipenv']


### PR DESCRIPTION
Fixes #8.