### PR TITLE
fix tox.ini content in README to avoid errors running tox under 2.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,8 +71,8 @@ This simple example will test against Python 2.7 and 3.6 using pytest to execute
 
         [testenv]
         deps = 
-        pytest
-        pytest-mock
+            pytest
+            pytest-mock
         commands = python -m pytest test/
 
 


### PR DESCRIPTION

Currently without the indentation for the `deps` in the `tox.ini` 
example file I was getting the exception below. This identation can be 
also seen on the official tox README

```
Traceback (most recent call last):
  File "/home/.virtualenvs/project-ePKRVxQ0/bin/tox", line 11, in <module>
    sys.exit(run_main())
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/tox/session.py", line 40, in run_main
    main(args)
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/tox/session.py", line 45, in main
    config = prepare(args)
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/tox/session.py", line 27, in prepare
    config = parseconfig(args)
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/tox/config.py", line 271, in parseconfig
    parseini(config, inipath)
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/tox/config.py", line 736, in __init__
    self._cfg = py.iniconfig.IniConfig(config.toxinipath)
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/py/_vendored_packages/iniconfig.py", line 54, in __init__
    tokens = self._parse(iter(f))
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/py/_vendored_packages/iniconfig.py", line 83, in _parse
    name, data = self._parseline(line, lineno)
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/py/_vendored_packages/iniconfig.py", line 133, in _parseline
    self._raise(lineno, 'unexpected line: %r' % line)
  File "/home/.virtualenvs/project-ePKRVxQ0/lib/python2.7/site-packages/py/_vendored_packages/iniconfig.py", line 77, in _raise
    raise ParseError(self.path, lineno, msg)
py._vendored_packages.iniconfig.ParseError: /home/Clients/project/code/project/tox.ini:9: unexpected line: 'pytest'
```