### PR TITLE
support pipenv installing pipfile requirements when tox.ini does not 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ ENV/
 env/
 pip-selfcheck.json
 Pipfile
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 
@@ -9,6 +8,9 @@ python:
 env:
   - TOX_VERSION="tox>=3.0,<3.1"
   - TOX_VERSION="tox>=3.1,<3.2"
+  - TOX_VERSION="tox>=3.2,<3.3"
+  - TOX_VERSION="tox>=3.3,<3.4"
+  - TOX_VERSION="tox>=3.4,<3.5"
 
 install:
   - pip install ${TOX_VERSION} tox-travis codecov

--- a/test/unit/test_testenv_install_deps.py
+++ b/test/unit/test_testenv_install_deps.py
@@ -15,7 +15,19 @@ def test_install_no_deps(venv, mocker, actioncls):
     mocker.patch("subprocess.Popen")
     result = tox_testenv_install_deps(venv, action)
     assert result == True
-    assert subprocess.Popen.call_count == 0
+    assert subprocess.Popen.call_count == 1
+    subprocess.Popen.assert_called_once_with(
+        [
+            sys.executable,
+            "-m",
+            "pipenv",
+            "install",
+            "--dev",
+        ],
+        action=action,
+        cwd=venv.path.dirpath(),
+        venv=False,
+    )
 
 
 def test_install_special_deps(venv, mocker, actioncls):

--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -81,14 +81,16 @@ def tox_testenv_install_deps(venv, action):
     basepath = venv.path.dirpath()
     basepath.ensure(dir=1)
     pipfile_path = _clone_pipfile(venv)
-    if deps:
-        args = [sys.executable, "-m", "pipenv", "install", "--dev"]
-        if action.venv.envconfig.pip_pre:
-            args.append('--pre')
-        with wrap_pipenv_environment(venv, pipfile_path):
+    args = [sys.executable, "-m", "pipenv", "install", "--dev"]
+    if action.venv.envconfig.pip_pre:
+        args.append('--pre')
+    with wrap_pipenv_environment(venv, pipfile_path):
+        if deps:
             action.setactivity("installdeps", "%s" % ",".join(list(map(str, deps))))
             args += list(map(str, deps))
-            venv._pcall(args, venv=False, action=action, cwd=basepath)
+        else:
+            action.setactivity("installdeps", "[]")
+        venv._pcall(args, venv=False, action=action, cwd=basepath)
 
     # Return non-None to indicate the plugin has completed
     return True


### PR DESCRIPTION
See #52 for details.

Running this plugin with no dependencies in your tox.ini will skip `python -m pipenv install --dev {deps}` because there aren't any.

However, in the pipenv documentation it says that when you call install it will load the pipfile by default. This meant that if you didn't provide deps in tox.ini but had some in pipfile, they wouldn't get installed with this plugin.

This update fixes that behaviour