### PR TITLE
Added support for --ignore-pipfile flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,11 @@ Is `Pipfile.lock` expected to be under source control?
 
 According to `pipenv` documentation, `Pipfile.lock` is not recommended under source control if it is going to be used under multiple Python versions.
 
+What if I still want to use dependencies from `Pipfile.lock`?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can add `ignore_pipfile = True` to tox.ini or run tox with `--ignore-pipfile` flag.
+
 What is the role of `requirements.txt` file?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,6 +20,7 @@ class MockEnvironmentConfig(object):
     sitepackages = False
     envdir = None
     pip_pre = False
+    ignore_pipfile = False
 
 
 class MockSession(object):

--- a/test/unit/test_testenv_install_deps.py
+++ b/test/unit/test_testenv_install_deps.py
@@ -107,6 +107,7 @@ def test_install_pip_ignore_pipfile(venv, mocker, actioncls):
             "install",
             "--dev",
             "--ignore-pipfile",
+            "--keep-outdated",
         ],
         action=action,
         cwd=venv.path.dirpath(),

--- a/test/unit/test_testenv_install_deps.py
+++ b/test/unit/test_testenv_install_deps.py
@@ -1,4 +1,3 @@
-import pytest
 from tox_pipenv.plugin import tox_testenv_install_deps
 import subprocess
 import os
@@ -58,7 +57,6 @@ def test_install_special_deps(venv, mocker, actioncls):
     )
 
 
-
 def test_install_pip_pre_deps(venv, mocker, actioncls):
     """
     Test that nothing is called when there are no deps
@@ -82,6 +80,33 @@ def test_install_pip_pre_deps(venv, mocker, actioncls):
             "--pre",
             "foo-package",
             "foo-two-package",
+        ],
+        action=action,
+        cwd=venv.path.dirpath(),
+        venv=False,
+    )
+
+
+def test_install_pip_ignore_pipfile(venv, mocker, actioncls):
+    """
+    Test that --ignore-pipfile flag is passed to pipenv executable
+    """
+    action = actioncls(venv)
+
+    mocker.patch.object(os, "environ", autospec=True)
+    mocker.patch.object(action.venv.envconfig, 'ignore_pipfile', True)
+    mocker.patch("subprocess.Popen")
+    result = tox_testenv_install_deps(venv, action)
+    assert result == True
+    assert subprocess.Popen.call_count == 1
+    subprocess.Popen.assert_called_once_with(
+        [
+            sys.executable,
+            "-m",
+            "pipenv",
+            "install",
+            "--dev",
+            "--ignore-pipfile",
         ],
         action=action,
         cwd=venv.path.dirpath(),

--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -221,8 +221,14 @@ def tox_addoption(parser):
 
 def _ignore_pipfile(venv):
     """ In case we want to use Pipfile.lock instead of Pipfile """
+    # Get the flag from tox.ini
     if venv.envconfig.ignore_pipfile is True:
         return True
-    if venv.envconfig.config.option.ignore_pipfile is True:
-        return True
+    # Get the flag from command line options
+    try:
+        if venv.envconfig.config.option.ignore_pipfile is True:
+            return True
+    except AttributeError:
+        pass
+
     return False

--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -43,7 +43,7 @@ def _clone_pipfile(venv):
 
     if _ignore_pipfile(venv):
         venv_pipfile_lock_path = venv.path.join("Pipfile.lock")
-        if not venv_pipfile_lock_path.check():
+        if root_pipfile_lock_path.exists() and not venv_pipfile_lock_path.check():
             root_pipfile_lock_path.copy(venv_pipfile_lock_path)
 
     return venv_pipfile_path
@@ -114,6 +114,7 @@ def tox_testenv_install_deps(venv, action):
 
     # Use Pipfile.lock instead of Pipfile
     if _ignore_pipfile(venv):
+        action.setactivity("pipenv", "using Pipfile.lock")
         args.append("--ignore-pipfile")
         args.append('--keep-outdated')  # so additional dependencies don't run locking process
 

--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -114,7 +114,9 @@ def tox_testenv_install_deps(venv, action):
     args = [sys.executable, "-m", "pipenv", "install", "--dev"]
     if venv.envconfig.pip_pre:
         args.append('--pre')
-
+    # Use Pipfile.lock instead of Pipfile
+    if venv.envconfig.ignore_pipfile:
+        args.append("--ignore-pipfile")
     with wrap_pipenv_environment(venv, pipfile_path):
         if deps:
             action.setactivity("installdeps", "%s" % ",".join(list(map(str, deps))))

--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -115,6 +115,8 @@ def tox_testenv_install_deps(venv, action):
     # Use Pipfile.lock instead of Pipfile
     if _ignore_pipfile(venv):
         args.append("--ignore-pipfile")
+        args.append('--keep-outdated')  # so additional dependencies don't run locking process
+
     with wrap_pipenv_environment(venv, pipfile_path):
         if deps:
             action.setactivity("installdeps", "%s" % ",".join(list(map(str, deps))))


### PR DESCRIPTION
Allow to run `pipenv install` with `--ignore-pipfile` flag, which will use Pipfile.lock instead of Pipfile and speedup test execution because dependencies don't need to be resolved.

https://github.com/tox-dev/tox-pipenv/issues/64