### PR TITLE
Remove trailing underscore

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ Welcome to tox-pipenv's documentation!
 What is tox?
 ------------
 
-tox is a generic virtualenv_ management and test command line tool you can use for:
+tox is a generic virtualenv management and test command line tool you can use for:
 
 * checking your package installs correctly with different Python versions and
   interpreters


### PR DESCRIPTION
It converted the word `virtualenv` into a link... to nowhere.